### PR TITLE
Fix ws urls: use latest token instead of a potentially expired one

### DIFF
--- a/src/utils/rest-api.js
+++ b/src/utils/rest-api.js
@@ -28,11 +28,8 @@ export function connectNotificationsWsUpdateConfig() {
         '/notify?appName=' +
         APP_NAME;
 
-    let webSocketUrlWithToken;
-    webSocketUrlWithToken = webSocketUrl + '&access_token=' + getToken();
-
     const reconnectingWebSocket = new ReconnectingWebSocket(
-        webSocketUrlWithToken
+        () => webSocketUrl + '&access_token=' + getToken()
     );
     reconnectingWebSocket.onopen = function (event) {
         console.info(


### PR DESCRIPTION
Signed-off-by: HARPER Jon <jon.harper87@gmail.com>