### PR TITLE
fix jest transpiling all node modules, make tests fast again

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,10 +51,11 @@
     },
     "jest": {
         "moduleNameMapper": {
-            "\\.svg": "<rootDir>/src/__mocks__/svgrMock.js"
+            "\\.svg": "<rootDir>/src/__mocks__/svgrMock.js",
+            "^.+\\.(css|less|scss)$": "identity-obj-proxy"
         },
         "transformIgnorePatterns": [
-            "node_modules/(?!@gridsuite/commons-ui)/"
+            "node_modules/(?!@gridsuite/commons-ui|react-dnd|dnd-core|@react-dnd)"
         ]
     },
     "eslintConfig": {


### PR DESCRIPTION
the previous regexp is bugged, it requires '//' in the filename !! As a result, all the files in node_modules don't pass the regex so nothing is ignored => everything is transformed

jest caches this in /tmp/jest_* so rerunning tests is fast, but the first time jest takes minutes to transform everything